### PR TITLE
current stable 2018

### DIFF
--- a/scripts/install_perl_on_nix.sh
+++ b/scripts/install_perl_on_nix.sh
@@ -2,7 +2,7 @@
 
 # Installer script for Perl on Linux/Unix systems
 
-INSTALLER_PERL_VERSION=5.20.1
+INSTALLER_PERL_VERSION=5.28.0
 
 BASHR=~/.bashrc
 CPANMTMP=~/.cpanm

--- a/scripts/install_perl_on_osx.sh
+++ b/scripts/install_perl_on_osx.sh
@@ -2,7 +2,7 @@
 
 # Installer script for Perl on Linux/Unix systems
 
-INSTALLER_PERL_VERSION=5.16.0
+INSTALLER_PERL_VERSION=5.28.0
 
 BASHP=~/.bash_profile
 BASHR=~/.bashrc


### PR DESCRIPTION
patch revises default installed perl version to 5.28.0 for unix and osx. This matches www.perl.org/get.html stable recommendations

5.16 was first released 2013-03-11
5.20 was first released 2015-09-12
5.28 was first released 2018-06-23
per en.wikipedia.org/wiki/Perl
